### PR TITLE
Make it build on Ubuntu 12.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.hi
 *.o
 generatejs
+generateJS
 gen/
 dist

--- a/JSGenerator.hs
+++ b/JSGenerator.hs
@@ -17,7 +17,6 @@ are safe in modern js engines.
 module JSGenerator 
   (program, getAll, enumerate)
   where
-import Prelude hiding (catch)
 import qualified Data.Set as Set
 import Control.Monad.Omega
 
@@ -416,11 +415,11 @@ labelledStatement = Nonterminal [[identifier, Terminal ":", statement]]
 throwStatement = Nonterminal [[Terminal " throw ", expression, Terminal ";"]]
 
 ----The try Statement
-tryStatement = Nonterminal [[Terminal " try ", block, catch],
+tryStatement = Nonterminal [[Terminal " try ", block, catch_],
                             [Terminal " try ", block, finally],
-                            [Terminal " try ", block, catch, finally]]
+                            [Terminal " try ", block, catch_, finally]]
 
-catch = Nonterminal [[Terminal " catch(", identifier, Terminal ")", block]]
+catch_ = Nonterminal [[Terminal " catch(", identifier, Terminal ")", block]]
 finally = Nonterminal [[Terminal " finally", block]]
 
 

--- a/generateJS.cabal
+++ b/generateJS.cabal
@@ -7,4 +7,4 @@ Build-Type:          Simple
 Cabal-Version:       >=1.2
 Executable generatejs
   Main-is:           generateJS.hs
-  Build-Depends:     base >= 3, haskell98, directory >=1, containers, control-monad-omega
+  Build-Depends:     base >= 3, directory >=1, containers, control-monad-omega

--- a/generateJS.hs
+++ b/generateJS.hs
@@ -11,7 +11,7 @@ module Main
   where
 import JSGenerator (getAll, program)
 import System.Directory
-import System
+import System.Environment
 import Text.Printf
 
 


### PR DESCRIPTION
This patch mitigates the problems caused by GHC 7.2.1 and newer not
supporting the use of haskell98 and the base package at the same time.
